### PR TITLE
Oz value id patch

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -240,37 +240,37 @@ impl Manager {
 
     pub fn enable_poll_with_intensity(&mut self, vid: &ValueID, intensity: u8) -> bool {
         unsafe {
-            extern_manager::manager_enable_poll_with_intensity(self.ptr, &vid.ozw_vid(), intensity)
+            extern_manager::manager_enable_poll_with_intensity(self.ptr, &vid.as_ozw_vid(), intensity)
         }
     }
 
     pub fn enable_poll(&mut self, vid: &ValueID) -> bool {
         unsafe {
-            extern_manager::manager_enable_poll(self.ptr, &vid.ozw_vid())
+            extern_manager::manager_enable_poll(self.ptr, &vid.as_ozw_vid())
         }
     }
 
     pub fn disable_poll(&mut self, vid: &ValueID) -> bool {
         unsafe {
-            extern_manager::manager_disable_poll(self.ptr, &vid.ozw_vid())
+            extern_manager::manager_disable_poll(self.ptr, &vid.as_ozw_vid())
         }
     }
 
     pub fn is_polled(&mut self, vid: &ValueID) -> bool {
         unsafe {
-            extern_manager::manager_is_polled(self.ptr, &vid.ozw_vid())
+            extern_manager::manager_is_polled(self.ptr, &vid.as_ozw_vid())
         }
     }
 
     pub fn set_poll_intensity(&mut self, vid: &ValueID, intensity: u8) {
         unsafe {
-            extern_manager::manager_set_poll_intensity(self.ptr, &vid.ozw_vid(), intensity)
+            extern_manager::manager_set_poll_intensity(self.ptr, &vid.as_ozw_vid(), intensity)
         }
     }
 
     pub fn get_poll_intensity(&mut self, vid: &ValueID) -> u8 {
         unsafe {
-            extern_manager::manager_get_poll_intensity(self.ptr, &vid.ozw_vid())
+            extern_manager::manager_get_poll_intensity(self.ptr, &vid.as_ozw_vid())
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -91,7 +91,7 @@ impl Node {
 
     pub fn get_basic(&self) -> Option<NodeBasic> {
         let manager_ptr = unsafe { extern_manager::get() };
-        NodeBasic::from_u8(unsafe { extern_manager::get_node_basic(manager_ptr, self.home_id, self.node_id)} )
+        NodeBasic::from_u8(unsafe { extern_manager::get_node_basic(manager_ptr, self.home_id, self.node_id) })
     }
 
     pub fn get_neighbors(&self) -> Option<Vec<Node>> {
@@ -142,12 +142,13 @@ impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.pad(&format!("{:3} {:17} {:30} {:50} {:30} {:30}",
                       self.get_id(),
-                      self.get_basic().map_or(String::from("unknown"), |basic| format!("{}", basic)),
+                      self.get_basic().map_or(String::from("unknown"), |basic| basic.to_string()),
                       self.get_type(),
                       self.get_product_name(),
                       self.get_name(),
                       self.get_location()
-                      ))
+                      )
+              )
     }
 }
 
@@ -196,7 +197,8 @@ impl fmt::Debug for Node {
                join(self.get_neighbors()
                         .unwrap_or(Vec::new())
                         .iter()
-                        .map(|node: &Node| node.simple_debug()), ", ")
+                        .map(|node: &Node| node.simple_debug()),
+                    ", ")
         )
     }
 }

--- a/src/value_classes/value_id.rs
+++ b/src/value_classes/value_id.rs
@@ -77,7 +77,7 @@ impl<'a> fmt::Debug for ValueList<'a> {
     }
 }
 
-#[derive(Eq, PartialEq, Clone, Hash)]
+#[derive(Eq, PartialEq, Clone, Copy, Hash)]
 pub struct ValueID {
     home_id: u32,
     id: u64

--- a/src/value_classes/value_id.rs
+++ b/src/value_classes/value_id.rs
@@ -24,7 +24,7 @@ impl<'a> ValueList<'a> {
         let mut raw_string: *mut c_char = ptr::null_mut();
 
         let res = unsafe {
-            extern_manager::get_value_list_selection_as_string(manager_ptr, &self.value_id.ozw_vid(), &mut raw_string, rust_string_creator)
+            extern_manager::get_value_list_selection_as_string(manager_ptr, &self.value_id.as_ozw_vid(), &mut raw_string, rust_string_creator)
         };
 
         if res {
@@ -37,7 +37,7 @@ impl<'a> ValueList<'a> {
     pub fn selection_as_int(&self) -> Result<i32, &str> {
         let manager_ptr = unsafe { extern_manager::get() };
         let mut val: i32 = 0;
-        let res = unsafe { extern_manager::get_value_list_selection_as_int(manager_ptr, &self.value_id.ozw_vid(), &mut val) };
+        let res = unsafe { extern_manager::get_value_list_selection_as_int(manager_ptr, &self.value_id.as_ozw_vid(), &mut val) };
         if res { Ok(val) } else { Err("Could not get the value") }
     }
 
@@ -45,7 +45,7 @@ impl<'a> ValueList<'a> {
         let manager_ptr = unsafe { extern_manager::get() };
         let mut c_items: *mut Vec<String> = ptr::null_mut();
         let c_items_void_ptr = &mut c_items as *mut *mut _ as *mut *mut c_void;
-        let res = unsafe { extern_manager::get_value_list_items(manager_ptr, &self.value_id.ozw_vid(), c_items_void_ptr, rust_string_vec_creator) };
+        let res = unsafe { extern_manager::get_value_list_items(manager_ptr, &self.value_id.as_ozw_vid(), c_items_void_ptr, rust_string_vec_creator) };
         if res {
             Ok(recover_vec(c_items))
         } else {
@@ -57,7 +57,7 @@ impl<'a> ValueList<'a> {
         let manager_ptr = unsafe { extern_manager::get() };
         let mut c_values: *mut Vec<i32> = ptr::null_mut();
         let c_values_void_ptr = &mut c_values as *mut *mut _ as *mut *mut c_void;
-        let res = unsafe { extern_manager::get_value_list_values(manager_ptr, &self.value_id.ozw_vid(), c_values_void_ptr, rust_vec_creator::<i32>) };
+        let res = unsafe { extern_manager::get_value_list_values(manager_ptr, &self.value_id.as_ozw_vid(), c_values_void_ptr, rust_vec_creator::<i32>) };
         if res {
             Ok(recover_vec(c_values))
         } else {
@@ -88,7 +88,7 @@ impl ValueID {
         ValueID { home_id: home_id, id: id }
     }
 
-    pub fn ozw_vid(&self) -> extern_value_id::ValueID {
+    pub fn as_ozw_vid(&self) -> extern_value_id::ValueID {
         unsafe { extern_value_id::value_id_from_packed_id(self.home_id, self.id) }
     }
 
@@ -128,27 +128,27 @@ impl ValueID {
     }
 
     pub fn get_node_id(&self) -> u8 {
-        unsafe { extern_value_id::value_id_get_node_id(&self.ozw_vid()) }
+        unsafe { extern_value_id::value_id_get_node_id(&self.as_ozw_vid()) }
     }
 
     pub fn get_genre(&self) -> ValueGenre {
-        unsafe { extern_value_id::value_id_get_genre(&self.ozw_vid()) }
+        unsafe { extern_value_id::value_id_get_genre(&self.as_ozw_vid()) }
     }
 
     pub fn get_command_class_id(&self) -> u8 {
-        unsafe { extern_value_id::value_id_get_command_class_id(&self.ozw_vid()) }
+        unsafe { extern_value_id::value_id_get_command_class_id(&self.as_ozw_vid()) }
     }
 
     pub fn get_instance(&self) -> u8 {
-        unsafe { extern_value_id::value_id_get_instance(&self.ozw_vid()) }
+        unsafe { extern_value_id::value_id_get_instance(&self.as_ozw_vid()) }
     }
 
     pub fn get_index(&self) -> u8 {
-        unsafe { extern_value_id::value_id_get_index(&self.ozw_vid()) }
+        unsafe { extern_value_id::value_id_get_index(&self.as_ozw_vid()) }
     }
 
     pub fn get_type(&self) -> ValueType {
-        unsafe { extern_value_id::value_id_get_type(&self.ozw_vid()) }
+        unsafe { extern_value_id::value_id_get_type(&self.as_ozw_vid()) }
     }
 
     pub fn get_id(&self) -> u64 {
@@ -161,7 +161,7 @@ impl ValueID {
             ValueType::ValueType_Bool | ValueType::ValueType_Button => {
                 let manager_ptr = unsafe { extern_manager::get() };
                 let mut val: bool = false;
-                let res = unsafe { extern_manager::get_value_as_bool(manager_ptr, &self.ozw_vid(), &mut val) };
+                let res = unsafe { extern_manager::get_value_as_bool(manager_ptr, &self.as_ozw_vid(), &mut val) };
                 if res { Ok(val) } else { Err("Could not get the value") }
             },
             _ => Err("Wrong type")
@@ -172,7 +172,7 @@ impl ValueID {
         if self.get_type() == ValueType::ValueType_Byte {
             let manager_ptr = unsafe { extern_manager::get() };
             let mut val: u8 = 0;
-            let res = unsafe { extern_manager::get_value_as_byte(manager_ptr, &self.ozw_vid(), &mut val) };
+            let res = unsafe { extern_manager::get_value_as_byte(manager_ptr, &self.as_ozw_vid(), &mut val) };
             if res { Ok(val) } else { Err("Could not get the value") }
         } else {
             Err("Wrong type")
@@ -183,7 +183,7 @@ impl ValueID {
         if self.get_type() == ValueType::ValueType_Decimal {
             let manager_ptr = unsafe { extern_manager::get() };
             let mut val: f32 = 0.;
-            let res = unsafe { extern_manager::get_value_as_float(manager_ptr, &self.ozw_vid(), &mut val) };
+            let res = unsafe { extern_manager::get_value_as_float(manager_ptr, &self.as_ozw_vid(), &mut val) };
             if res { Ok(val) } else { Err("Could not get the value") }
         } else {
             Err("Wrong type")
@@ -194,7 +194,7 @@ impl ValueID {
         if self.get_type() == ValueType::ValueType_Decimal {
             let manager_ptr = unsafe { extern_manager::get() };
             let mut val: u8 = 0;
-            let res = unsafe { extern_manager::get_value_float_precision(manager_ptr, &self.ozw_vid(), &mut val) };
+            let res = unsafe { extern_manager::get_value_float_precision(manager_ptr, &self.as_ozw_vid(), &mut val) };
             if res { Ok(val) } else { Err("Could not get the value") }
         } else {
             Err("Wrong type")
@@ -205,7 +205,7 @@ impl ValueID {
         if self.get_type() == ValueType::ValueType_Int {
             let manager_ptr = unsafe { extern_manager::get() };
             let mut val: i32 = 0;
-            let res = unsafe { extern_manager::get_value_as_int(manager_ptr, &self.ozw_vid(), &mut val) };
+            let res = unsafe { extern_manager::get_value_as_int(manager_ptr, &self.as_ozw_vid(), &mut val) };
             if res { Ok(val) } else { Err("Could not get the value") }
         } else {
             Err("Wrong type")
@@ -216,7 +216,7 @@ impl ValueID {
         if self.get_type() == ValueType::ValueType_Short {
             let manager_ptr = unsafe { extern_manager::get() };
             let mut val: i16 = 0;
-            let res = unsafe { extern_manager::get_value_as_short(manager_ptr, &self.ozw_vid(), &mut val) };
+            let res = unsafe { extern_manager::get_value_as_short(manager_ptr, &self.as_ozw_vid(), &mut val) };
             if res { Ok(val) } else { Err("Could not get the value") }
         } else {
             Err("Wrong type")
@@ -229,7 +229,7 @@ impl ValueID {
         let mut raw_string: *mut c_char = ptr::null_mut();
 
         let res = unsafe {
-            extern_manager::get_value_as_string(manager_ptr, &self.ozw_vid(), &mut raw_string, rust_string_creator)
+            extern_manager::get_value_as_string(manager_ptr, &self.as_ozw_vid(), &mut raw_string, rust_string_creator)
         };
 
         if res {
@@ -245,7 +245,7 @@ impl ValueID {
             let raw_ptr_c_void = &mut raw_ptr as *mut *mut _ as *mut *mut c_void;
 
             let manager_ptr = unsafe { extern_manager::get() };
-            let res = unsafe { extern_manager::get_value_as_raw(manager_ptr, &self.ozw_vid(), raw_ptr_c_void, rust_vec_creator::<u8>) };
+            let res = unsafe { extern_manager::get_value_as_raw(manager_ptr, &self.as_ozw_vid(), raw_ptr_c_void, rust_vec_creator::<u8>) };
 
             if res {
                 Ok(recover_vec(raw_ptr))
@@ -269,7 +269,7 @@ impl ValueID {
         recover_string(
             unsafe {
                 let manager_ptr = extern_manager::get();
-                extern_manager::get_value_label(manager_ptr, &self.ozw_vid(), rust_string_creator)
+                extern_manager::get_value_label(manager_ptr, &self.as_ozw_vid(), rust_string_creator)
             }
         )
     }
@@ -278,7 +278,7 @@ impl ValueID {
         unsafe {
             let manager_ptr = extern_manager::get();
             let c_string = try!(CString::new(str)).as_ptr();
-            extern_manager::set_value_label(manager_ptr, &self.ozw_vid(), c_string);
+            extern_manager::set_value_label(manager_ptr, &self.as_ozw_vid(), c_string);
             Ok(())
         }
     }
@@ -287,7 +287,7 @@ impl ValueID {
         recover_string(
             unsafe {
                 let manager_ptr = extern_manager::get();
-                extern_manager::get_value_units(manager_ptr, &self.ozw_vid(), rust_string_creator)
+                extern_manager::get_value_units(manager_ptr, &self.as_ozw_vid(), rust_string_creator)
             }
         )
     }
@@ -296,7 +296,7 @@ impl ValueID {
         unsafe {
             let manager_ptr = extern_manager::get();
             let c_string = try!(CString::new(str)).as_ptr();
-            extern_manager::set_value_units(manager_ptr, &self.ozw_vid(), c_string);
+            extern_manager::set_value_units(manager_ptr, &self.as_ozw_vid(), c_string);
             Ok(())
         }
     }
@@ -305,7 +305,7 @@ impl ValueID {
         recover_string(
             unsafe {
                 let manager_ptr = extern_manager::get();
-                extern_manager::get_value_help(manager_ptr, &self.ozw_vid(), rust_string_creator)
+                extern_manager::get_value_help(manager_ptr, &self.as_ozw_vid(), rust_string_creator)
             }
         )
     }
@@ -314,7 +314,7 @@ impl ValueID {
         unsafe {
             let manager_ptr = extern_manager::get();
             let c_string = try!(CString::new(str)).as_ptr();
-            extern_manager::set_value_help(manager_ptr, &self.ozw_vid(), c_string);
+            extern_manager::set_value_help(manager_ptr, &self.as_ozw_vid(), c_string);
             Ok(())
         }
     }
@@ -322,42 +322,42 @@ impl ValueID {
     pub fn get_min(&self) -> i32 {
         unsafe {
             let manager_ptr = extern_manager::get();
-            extern_manager::get_value_min(manager_ptr, &self.ozw_vid())
+            extern_manager::get_value_min(manager_ptr, &self.as_ozw_vid())
         }
     }
 
     pub fn get_max(&self) -> i32 {
         unsafe {
             let manager_ptr = extern_manager::get();
-            extern_manager::get_value_max(manager_ptr, &self.ozw_vid())
+            extern_manager::get_value_max(manager_ptr, &self.as_ozw_vid())
         }
     }
 
     pub fn is_read_only(&self) -> bool {
         unsafe {
             let manager_ptr = extern_manager::get();
-            extern_manager::is_value_read_only(manager_ptr, &self.ozw_vid())
+            extern_manager::is_value_read_only(manager_ptr, &self.as_ozw_vid())
         }
     }
 
     pub fn is_write_only(&self) -> bool {
         unsafe {
             let manager_ptr = extern_manager::get();
-            extern_manager::is_value_write_only(manager_ptr, &self.ozw_vid())
+            extern_manager::is_value_write_only(manager_ptr, &self.as_ozw_vid())
         }
     }
 
     pub fn is_set(&self) -> bool {
         unsafe {
             let manager_ptr = extern_manager::get();
-            extern_manager::is_value_set(manager_ptr, &self.ozw_vid())
+            extern_manager::is_value_set(manager_ptr, &self.as_ozw_vid())
         }
     }
 
     pub fn is_polled(&self) -> bool {
         unsafe {
             let manager_ptr = extern_manager::get();
-            extern_manager::is_value_polled(manager_ptr, &self.ozw_vid())
+            extern_manager::is_value_polled(manager_ptr, &self.as_ozw_vid())
         }
     }
 }
@@ -421,7 +421,7 @@ use std::cmp::{self, Ordering};
 
 impl cmp::PartialOrd for ValueID {
     fn partial_cmp(&self, other: &ValueID) -> Option<Ordering> {
-        let is_less_than = unsafe { extern_value_id::value_id_less_than(&self.ozw_vid(), &other.ozw_vid()) };
+        let is_less_than = unsafe { extern_value_id::value_id_less_than(&self.as_ozw_vid(), &other.as_ozw_vid()) };
         if is_less_than {
             Some(Ordering::Less)
         } else if self.eq(other) {


### PR DESCRIPTION
First commit:
- minor formatting changes
- minor change for how we convert basic to a string

Second commit:
- rename ozw_vid to as_ozw_vid for rusty conventions 
